### PR TITLE
remove double underline on footer links

### DIFF
--- a/index.html
+++ b/index.html
@@ -358,12 +358,12 @@
         </p>
 
         <p>
-          <a class="link--footer link--legal" href="https://www.mozilla.org/en-US/privacy/websites/" target="_blank">Privacy Policy</a> &nbsp;
-          <a class="link--footer link--legal" href="https://www.mozilla.org/en-US/about/legal/" target="_blank">Legal Notices</a> &nbsp;
-          <a class="link--footer link--legal" href="https://www.mozilla.org/en-US/about/legal/fraud-report/" target="_blank">Report Trademark Abuse</a>
+          <a class="link--footer link--legal no-decoration" href="https://www.mozilla.org/en-US/privacy/websites/" target="_blank">Privacy Policy</a> &nbsp;
+          <a class="link--footer link--legal no-decoration" href="https://www.mozilla.org/en-US/about/legal/" target="_blank">Legal Notices</a> &nbsp;
+          <a class="link--footer link--legal no-decoration" href="https://www.mozilla.org/en-US/about/legal/fraud-report/" target="_blank">Report Trademark Abuse</a>
         </p>
         <p class="footer__license">
-          Except where otherwise <a class="link--footer link--license" href="https://www.mozilla.org/en-US/about/legal/#site">noted</a>, content of this site is licensed under the <a class="link--footer link--license" href="https://www.mozilla.org/en-US/foundation/licensing/website-content">Creative Commons</a> <a class="link--footer link--license" href="http://creativecommons.org/licenses/by-sa/3.0">Attribution Share-Alike License v3.0</a> or any later.
+          Except where otherwise <a class="link--footer link--license no-decoration" href="https://www.mozilla.org/en-US/about/legal/#site">noted</a>, content of this site is licensed under the <a class="link--footer link--license no-decoration" href="https://www.mozilla.org/en-US/foundation/licensing/website-content">Creative Commons</a> <a class="link--footer link--license no-decoration" href="http://creativecommons.org/licenses/by-sa/3.0">Attribution Share-Alike License v3.0</a> or any later.
         </p>
       </div>
     </footer>


### PR DESCRIPTION
## before
![screenshot 2016-01-18 22 57 28](https://cloud.githubusercontent.com/assets/203725/12411876/d849e4cc-be36-11e5-87b5-5b185baabb1f.png)

## after
![screenshot 2016-01-18 22 58 07](https://cloud.githubusercontent.com/assets/203725/12411887/eadde73c-be36-11e5-8684-8f73fa1af598.png)
