### PR TITLE
add News section (fixes #13)

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -155,6 +155,7 @@ salmon: #e14164
 
 html, body {
   background: #fff;
+  width: 100%;
 }
 
 html {
@@ -500,6 +501,57 @@ Top intro section
   text-shadow: 1px 1px rgba(0, 0, 0, 0.5);
 }
 
+
+/*
+News
+*/
+.section--news {
+  background: #efefff;
+}
+
+.section--news h2 {
+  color: #1f366c;
+}
+
+.posts {
+  list-style: none;
+}
+
+.post__title {
+  border-bottom: 1px dotted rgba(0,0,0,0.25);
+  padding-bottom: 1px;
+}
+
+.post__date {
+  float: right;
+  font-weight: 400;
+  opacity: 0.5;
+  padding-bottom: 2px;
+}
+
+.post__link,
+.post__date {
+  transition: 0.05s ease-in-out;
+}
+
+.post__link {
+  color: #0c99d5;
+  display: block;
+  font-weight: 500;
+  padding: 0.1rem 0;
+}
+
+.post__link:hover {
+  color: #1f366c;
+}
+
+.post__link:hover .post__title {
+  border-bottom-color: rgba(0,0,0,0.8);
+}
+
+.post__link:hover .post__date {
+  opacity: 0.75;
+}
 
 /*
 Getting Started

--- a/index.html
+++ b/index.html
@@ -27,6 +27,7 @@
       <a href="#top" class="nav__top no-decoration">MozVR</a>
 
       <ul>
+        <li class="nav__item"><a class="no-decoration" href="#news">News</a></li>
         <li class="nav__item"><a class="no-decoration" href="#start">Getting Started</a></li>
         <li class="nav__item"><a class="no-decoration" href="#showcase">Showcase</a></li>
         <li class="nav__item"><a class="no-decoration" href="#developers">Developers</a></li>
@@ -53,6 +54,19 @@
     </header>
 
     <div class="flex--vertical">
+      <section class="section section--news copy">
+        <div id="news" class="section__anchor"></div>
+        <div class="wrap wrap--narrow">
+          <h1>News</h1>
+          <ol class="posts">
+            <li class="post__item"><a class="post__link no-decoration" href="https://medium.com/@mozvr/oculus-0-8-runtime-support-landing-in-firefox-nightly-5ddbd2ad3354"><span class="post__title">Oculus 0.8 Runtime Support Landing in Firefox Nightly</span> <time class="post__date">Jan 6, 2016</time></a></li>
+            <li class="post__item"><a class="post__link no-decoration" href="https://medium.com/@mozvr/webvr-enabled-by-default-in-firefox-nightly-6325b7d2eb95"><span class="post__title">WebVR Enabled by Default in Firefox Nightly</span> <time class="post__date">Jan 5, 2016</time></a></li>
+            <li class="post__item"><a class="post__link no-decoration" href="https://medium.com/@mozvr/making-sechelt-with-three-js-and-cinema-4d-827a378409c0"><span class="post__title">Making Sechelt With three.js and Cinema 4D</span> <time class="post__date">Dec 10, 2014</time></a></li>
+            <li class="post__item"><a class="post__link no-decoration" href="https://medium.com/@mozvr/quick-vr-mockups-with-illustrator-e7bba2f493b8"><span class="post__title">Quick VR Mockups with Illustrator</span> <time class="post__date">Dec 9, 2014</time></a></li>
+          </ol>
+        </div>
+      </section>
+
       <section class="section section--start copy">
         <div id="start" class="section__anchor"></div>
         <div class="wrap wrap--narrow">


### PR DESCRIPTION
r? @caseyyee @jcarpenter

<hr>

I first created a [Twitter account (@mozvr_)](https://twitter.com/mozvr_) for us (since [@mozvr](https://twitter.com/mozvr) isn't available yet).

I first created a [Tumblr blog for MozVR](http://mozvr.tumblr.com/). @caseyyee said this: 

> on blog platform:  would medium be better?   It has better tools for sharing/commenting which I think would be useful.

So I created a [Medium account](https://medium.com/@mozvr) for us. So far, all of the posts are _private_ (i.e., accessible only from the URLs). But I've created a blog post for the two relevant blog posts from the old site and two short posts that I wrote up based on Kip's original /r/webvr Reddit posts:

* [Oculus 0.8 Runtime Support Landing in Firefox Nightly](https://medium.com/@mozvr/oculus-0-8-runtime-support-landing-in-firefox-nightly-5ddbd2ad3354)
* [WebVR Enabled by Default in Firefox Nightly](https://medium.com/@mozvr/webvr-enabled-by-default-in-firefox-nightly-6325b7d2eb95)
* [Making Sechelt With three.js and Cinema 4D](https://medium.com/@mozvr/making-sechelt-with-three-js-and-cinema-4d-827a378409c0)
* [Quick VR Mockups with Illustrator](https://medium.com/@mozvr/making-sechelt-with-three-js-and-cinema-4d-827a378409c0)

<hr>

# Screenshots

## Firefox (when VR is supported)

### Before
![screenshot 2016-01-20 18 50 32](https://cloud.githubusercontent.com/assets/203725/12470158/c4b36b6a-bfa6-11e5-9a35-7bdb3062be75.png)

### After
![screenshot 2016-01-20 18 52 00](https://cloud.githubusercontent.com/assets/203725/12470169/d9b381ee-bfa6-11e5-9627-f573e543f246.png)


## Chrome (when VR is unsupported)

### Before
![screenshot 2016-01-20 18 52 55](https://cloud.githubusercontent.com/assets/203725/12470182/fdf4ee30-bfa6-11e5-8a65-fc9b6daada8c.png)

### After
![screenshot 2016-01-20 18 52 47](https://cloud.githubusercontent.com/assets/203725/12470181/fdf37e6a-bfa6-11e5-88ad-3b4faa19d063.png)
