### PR TITLE
make slogan more readable (fixes #9)

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -494,10 +494,13 @@ Top intro section
 }
 
 .headline {
+  background: rgba(0,0,0,.5);
+  box-shadow: -3px 3px 0 0 rgba(0,0,0,.15);
   font-size: 1.2rem;
   color: #fff;
   max-width: 35rem;
   margin: 3rem;
+  padding: 0.5rem 1rem;
   text-shadow: 1px 1px rgba(0, 0, 0, 0.5);
 }
 

--- a/index.html
+++ b/index.html
@@ -48,7 +48,7 @@
         <div class="hero--headline copy--center">
           <h1 class="wordmark">MOZVR</h1>
 
-          <h2 class="headline">We are the Mozilla VR team. Our goal is to help bring high performance virtual reality to the open web.</h2>
+          <h2 class="headline">We are the Mozilla VR team. Our goal is to help bring high-performance virtual reality to the open web.</h2>
         </div>
       </div>
     </header>


### PR DESCRIPTION
# before
<img width="500" alt="screenshot 2016-02-12 14 43 20" src="https://cloud.githubusercontent.com/assets/203725/13022548/2d1bd73a-d197-11e5-840e-2fdaf91b0b65.png">

# after
<img width="500" alt="screenshot 2016-02-12 14 43 10" src="https://cloud.githubusercontent.com/assets/203725/13022549/2d575cb0-d197-11e5-84ae-876ed91ac3e5.png">
