### PR TITLE
copy over `demos` directory for prod

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "start": "npm run dev",
     "dev": "http-server -c-1",
     "build": "rm -rf _build && mkdir -p _build/assets/css/ && postcss --use autoprefixer assets/css/style.css -d _build/assets/css/ --browsers 'last 10 versions' --map --no-cascade",
-    "prod": "npm run build && rm -rf _prod && mkdir -p _prod && cp -r {.nojekyll,CNAME,assets,*.html,showcase} _prod/. 2>/dev/null || : && cp -r _build/* _prod/. && node scripts/generate-redirects.js",
+    "prod": "npm run build && rm -rf _prod && mkdir -p _prod && cp -r {.nojekyll,CNAME,assets,demos,*.html,showcase} _prod/. 2>/dev/null || : && cp -r _build/* _prod/. && node scripts/generate-redirects.js",
     "preghpages": "npm run prod",
     "ghpages": "ghpages",
     "gh-pages": "npm run ghpages",


### PR DESCRIPTION
the `demos/` directory was not getting copied when generating the prod version of the site. in the future, we should consider using [oghliner](https://github.com/mozilla/oghliner) (see issue #57).