### PR TITLE
link to Blog at mobile widths (fixes #60)

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -780,6 +780,10 @@ a.link--license:hover {
   color: #86d6f8;
 }
 
+.link--blog {
+  display: none;
+}
+
 /*
 media queries
 */
@@ -790,6 +794,17 @@ media queries
   }
   .flex--grid--item {
     flex-basis: 50%;
+  }
+  .link--blog {
+    background: #e14164;
+    display: inline-block;
+    color: #fff;
+    font-weight: 400;
+    letter-spacing: 0.1rem;
+    margin: 0 auto 1.5rem;
+    padding: 0.5rem 2rem;
+    text-align: center;
+    text-transform: uppercase;
   }
 }
 

--- a/index.html
+++ b/index.html
@@ -332,6 +332,8 @@
     <footer class="section section--footer section--thin copy copy--bright copy--center">
       <div id="footer" class="section__anchor"></div>
       <div class="wrap wrap--footer">
+        <a href="https://mozvr.ghost.io/" class="link--blog" target="_blank">View Blog</a>
+
         <div class="footer__icons">
           <p>
             <a href="https://www.mozilla.org/"><img class="icon icon--mozilla" src="assets/img/logo-mozilla-white.svg" alt="Mozilla"></a>


### PR DESCRIPTION
since we're ramping up our social presence, I wanted to make sure mobile folks could see the link asap. quick and dirty:

<img width="314" alt="screenshot 2016-02-23 00 21 43" src="https://cloud.githubusercontent.com/assets/203725/13245672/9870dc36-d9c3-11e5-82d4-86870a8975b4.png">

open to alternate treatments