### PR TITLE
clean up Sechelt styles (fix font-family when iframe is embedded in Chrome)

### DIFF
--- a/demos/sechelt/index.html
+++ b/demos/sechelt/index.html
@@ -3,7 +3,14 @@
   <head>
     <title>Sechelt</title>
     <meta charset="utf-8">
+    <script>
+      document.documentElement.setAttribute('data-is-firefox', 'InstallTrigger' in window);
+    </script>
     <style>
+    html {
+      font-size: 14px;
+    }
+
     html, body {
       background-color: none transparent;
       color: #fff;
@@ -16,24 +23,45 @@
     }
 
     .vr #enterVr {
-      display: block;
-      position: absolute;
-      bottom: 20px;
-      width: 100%;
-      text-align: center;
-      margin: auto;
       background: transparent;
       border: 0;
+      bottom: 0;
       color: #fff;
-      padding: 10px;
-      font-size: 0.8rem;
+      cursor: pointer;
+      display: block;
+      font-size: 1rem;
+      letter-spacing: 0.05ch;
+      line-height: 1.5;
+      margin: auto;
+      opacity: 0.85;
+      padding: 1px 1px 31px;
+      position: absolute;
+      text-align: center;
+      width: 100%;
+    }
+
+    .vr #enterVr:before {
+      background: url(../../assets/img/icon-goggles-white.svg) 50% 0 no-repeat;
+      background-size: contain;
+      content: "";
+      display: block;
+      height: 33px;
+      margin-bottom: 5px;
+    }
+
+    .vr #enterVr:hover {
+      opacity: 1;
+    }
+
+    /* Styles and web fonts cascade with Firefox only, so we explicitly set the `font-family` */
+    [data-is-firefox="false"] .vr #enterVr {
+      font-family: Fira Sans, Helvetica Neue, Helvetica, sans-serif;
     }
     </style>
   </head>
 
   <body>
     <button id="enterVr">
-      <img height="30" class="icon icon--social" src="../../assets/img/icon-goggles-white.svg"><br/>
       ENTER VR
     </button>
     <script src="js/three.min.js"></script>

--- a/index.html
+++ b/index.html
@@ -43,7 +43,7 @@
 
     <header id="header" class="header">
       <div id="hero" class="hero flex flex--center">
-        <iframe class="hero--iframe" allowfullscreen allowtransparency="true" data-src="demos/sechelt/?sound=false"></iframe>
+        <iframe class="hero--iframe" allowfullscreen seamless data-src="demos/sechelt/?sound=false"></iframe>
 
         <div class="hero--headline copy--center">
           <h1 class="wordmark">MOZVR</h1>


### PR DESCRIPTION
## before

### Chrome
![screenshot 2016-02-25 15 25 39](https://cloud.githubusercontent.com/assets/203725/13338183/949c3ec6-dbd4-11e5-88fb-5aa826c4c01a.png)

### Firefox
<img width="1087" alt="screenshot 2016-02-25 15 25 10" src="https://cloud.githubusercontent.com/assets/203725/13338184/949c5a00-dbd4-11e5-821e-cdfc616f8dae.png">

## after

### Chrome
![screenshot 2016-02-25 15 26 26](https://cloud.githubusercontent.com/assets/203725/13338182/949c5618-dbd4-11e5-859c-76abe740c6f9.png)

### Firefox
<img width="1087" alt="screenshot 2016-02-25 15 24 55" src="https://cloud.githubusercontent.com/assets/203725/13338185/949d1eea-dbd4-11e5-9f47-2809fcf02344.png">
