### PR TITLE
hide sites not updated for WebVR API v1.0	

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -788,6 +788,14 @@ a.link--license:hover {
   display: none;
 }
 
+/* Hide WebVR pages that haven't been updated for the new API. */
+[data-supports-vr="false"][data-supports-vr-legacy="true"] [data-showcase-slug="inspirit"],
+[data-supports-vr="false"][data-supports-vr-legacy="true"] [data-showcase-slug="livyatanim"],
+[data-supports-vr="false"][data-supports-vr-legacy="true"] [data-showcase-slug="monkeys"],
+[data-supports-vr="false"][data-supports-vr-legacy="true"] [data-showcase-slug="rainbowmembrane"] {
+  display: none;
+}
+
 /*
 media queries
 */

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -36,7 +36,7 @@ function $$ (selector, parent) {
 var body = document.body;
 
 // Adding an attribute so we can disable certain :hover styles on touch.
-// NOTE: Not using classList `dataset` IE compatibility.
+// NOTE: Not using `dataset` for IE compatibility.
 body.setAttribute('data-supports-touch', 'ontouchstart' in window);
 
 // And an attribute for WebVR support.

--- a/index.html
+++ b/index.html
@@ -122,7 +122,7 @@
           </div>
 
           <ul class="flex flex--grid flex--grid--stretch showcase__grid">
-            <li class="flex flex--grid--item showcase__item">
+            <li class="flex flex--grid--item showcase__item" data-showcase-slug="videosphere">
               <a class="showcase__link no-decoration" href="https://aframe.io/examples/showcase/videosphere/">
                 <div class="showcase__image" style="background-image: url(assets/img/showcase/360video.png)"></div>
 
@@ -131,7 +131,7 @@
               </a>
             </li>
 
-            <li class="flex flex--grid--item showcase__item">
+            <li class="flex flex--grid--item showcase__item" data-showcase-slug="shopping">
               <a class="showcase__link no-decoration" href="https://aframe.io/examples/showcase/shopping/">
                 <div class="showcase__image" style="background-image: url(assets/img/showcase/shopping.png)"></div>
 
@@ -140,7 +140,7 @@
               </a>
             </li>
 
-            <li class="flex flex--grid--item showcase__item desktop">
+            <li class="flex flex--grid--item showcase__item desktop" data-showcase-slug="livyatanim">
               <a class="showcase__link no-decoration" href="http://film.livyatanim.com/">
                 <div class="showcase__image" style="background-image: url(assets/img/showcase/livyatanim.png)"></div>
 
@@ -149,7 +149,7 @@
               </a>
             </li>
 
-            <li class="flex flex--grid--item showcase__item desktop">
+            <li class="flex flex--grid--item showcase__item desktop" data-showcase-slug="monkeys">
               <a class="showcase__link no-decoration" href="http://monkeys.hypernom.com/">
                 <div class="showcase__image" style="background-image: url(assets/img/showcase/monkeys.png)"></div>
 
@@ -158,7 +158,7 @@
               </a>
             </li>
 
-            <li class="flex flex--grid--item showcase__item">
+            <li class="flex flex--grid--item showcase__item" data-showcase-slug="panorama">
               <a class="showcase__link no-decoration" href="https://mozvr.github.io/panorama-viewer/">
                 <div class="showcase__image" style="background-image: url(assets/img/showcase/panorama.png)"></div>
 
@@ -168,7 +168,7 @@
               </a>
             </li>
 
-            <li class="flex flex--grid--item showcase__item desktop">
+            <li class="flex flex--grid--item showcase__item desktop" data-showcase-slug="rainbowmembrane">
               <a class="showcase__link no-decoration" href="http://cabbi.bo/RainbowMembrane/">
                 <div class="showcase__image" style="background-image: url(assets/img/showcase/rainbowmembrane.png)"></div>
 
@@ -178,7 +178,7 @@
               </a>
             </li>
 
-            <li class="flex flex--grid--item showcase__item">
+            <li class="flex flex--grid--item showcase__item" data-showcase-slug="sechelt">
               <a class="showcase__link no-decoration" href="https://mozvr.github.io/sechelt/">
                 <div class="showcase__image" style="background-image: url(assets/img/showcase/sechelt.png)"></div>
 
@@ -188,7 +188,7 @@
               </a>
             </li>
 
-            <li class="flex flex--grid--item showcase__item">
+            <li class="flex flex--grid--item showcase__item" data-showcase-slug="polarsea">
               <a class="showcase__link no-decoration" href="demos/polarsea/">
                 <div class="showcase__image" style="background-image: url(assets/img/showcase/polarsea.png)"></div>
 
@@ -198,7 +198,7 @@
               </a>
             </li>
 
-            <li class="flex flex--grid--item showcase__item">
+            <li class="flex flex--grid--item showcase__item" data-showcase-slug="inspirit">
               <a class="showcase__link no-decoration" href="http://inspirit.unboring.net/">
                 <div class="showcase__image" style="background-image: url(assets/img/showcase/inspirit.png)"></div>
 


### PR DESCRIPTION
since we own/host 5 of the 9 Showcase items, for now we can guarantee only those will be updated to support the upcoming changes to the WebVR API (i.e., the new version of the webvr-polyfill).

once the new sites update their polyfills (I'll contact them), we can expose them again for the new builds.

### before
![screenshot 2016-02-25 15 26 26](https://cloud.githubusercontent.com/assets/203725/13338789/9ce6c2be-dbd8-11e5-9111-1611584bef84.png)

### after
<img width="1208" alt="screenshot 2016-02-25 15 57 47" src="https://cloud.githubusercontent.com/assets/203725/13338813/c3317928-dbd8-11e5-8f7c-2389ed1cc666.png">
